### PR TITLE
Docs: Fix data dependencies link in rules.md

### DIFF
--- a/docs/go/core/rules.md
+++ b/docs/go/core/rules.md
@@ -12,7 +12,7 @@
   [cc_library deps]: https://docs.bazel.build/versions/master/be/c-cpp.html#cc_library.deps
   [cgo]: http://golang.org/cmd/cgo/
   [config_setting]: https://docs.bazel.build/versions/master/be/general.html#config_setting
-  [data dependencies]: https://docs.bazel.build/versions/master/build-ref.html#data
+  [data dependencies]: [https://docs.bazel.build/versions/master/build-ref.html#data](https://bazel.build/concepts/dependencies#data-dependencies)
   [goarch]: /go/modes.rst#goarch
   [goos]: /go/modes.rst#goos
   [mode attributes]: /go/modes.rst#mode-attributes


### PR DESCRIPTION
The link brings the reader to the root bazel docs. Update the link to point directly at the data dependencies section

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Documentation

**What does this PR do? Why is it needed?**

The link currently points at the root bazel documentation. Should update the link to point at the correct section of the online docs